### PR TITLE
Add options to catch custom errors and custom Proc to run before retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+### Unreleased
+
+* Add `TransactionRetry.before_retry` configuration option to run Proc before transaction retry
+* Add `TransactionRetry.retry_on` configuration option to include more Errors to retry on
+* Update dependency ruby 2.2.2
+
+### 1.1.0

--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ __after__ connecting to the database.
 
 You can optionally configure transaction_retry gem in your config/initializers/transaction_retry.rb (or anywhere else):
 
+```
     TransactionRetry.max_retries = 3
     TransactionRetry.wait_times = [0, 1, 2, 4, 8, 16, 32]   # seconds to sleep after retry n
+    TransactionRetry.retry_on = CustomErrorClass # or an array of classes is valid too (ActiveRecord::TransactionIsolationConflict is by default always included)
+    TransactionRetry.before_retry = ->(retry_num, error) { ... }
+```
 
 ## Features
 
@@ -56,6 +60,7 @@ You can optionally configure transaction_retry gem in your config/initializers/t
  * Logs every retry as a warning.
  * Intentionally does not retry nested transactions.
  * Configurable number of retries and sleep time between them.
+ * Configure a custom hook to run before every retry.
  * Use it in your Rails application or a standalone ActiveRecord-based project.
 
 ## Testimonials
@@ -64,7 +69,7 @@ This gem was initially developed for and successfully works in production at [Ko
 
 ## Requirements
 
- * ruby 1.9.2
+ * ruby 2.2.2+
  * activerecord 3.0.11+
 
 ## Running tests

--- a/lib/transaction_retry.rb
+++ b/lib/transaction_retry.rb
@@ -1,6 +1,5 @@
 require "active_record"
 require "transaction_isolation"
-
 require_relative "transaction_retry/version"
 
 module TransactionRetry
@@ -20,6 +19,22 @@ module TransactionRetry
         TransactionRetry.apply_activerecord_patch
       end
     end
+  end
+
+  def self.before_retry=(lambda_block)
+    @@before_retry = lambda_block
+  end
+
+  def self.before_retry
+    @@before_retry ||= nil
+  end
+
+  def self.retry_on=(error_classes)
+    @@retry_on = Array(error_classes)
+  end
+
+  def self.retry_on
+    @@retry_on ||= []
   end
 
   def self.max_retries

--- a/transaction_retry.gemspec
+++ b/transaction_retry.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/qertoip/transaction_retry"
   s.summary     = %q{Retries database transaction on deadlock and transaction serialization errors. Supports MySQL, PostgreSQL and SQLite.}
   s.description = %q{Retries database transaction on deadlock and transaction serialization errors. Supports MySQL, PostgreSQL and SQLite (as long as you are using new drivers mysql2, pg, sqlite3).}
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 2.2.2'
   
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
* Add TransactionRetry.before_retry configuration option to run Proc before transaction retry
```
TransactionRetry.retry_on = CustomErrorClass # or an array of classes is valid too 
```

* Add TransactionRetry.retry_on configuration option to include more Errors to retry on

```
TransactionRetry.before_retry = ->(retry_num, error) { ... }
```

* Update ruby dependency to >= 2.2.2